### PR TITLE
💄 Visited links doesn't change color anymore

### DIFF
--- a/sass/_links.scss
+++ b/sass/_links.scss
@@ -6,10 +6,6 @@ a {
   font-weight: 400;
 }
 
-a:visited {
-  color: variables.$Chimera-darkest;
-}
-
 a:hover {
   color: variables.$Chimera-dark;
   cursor: pointer;


### PR DESCRIPTION
I think links shouldn't change color when visited, because:

Aesthetic Consistency: A uniform color for links can maintain aesthetic consistency throughout the website. Potential risk is affecting the user’s visual experience negatively.

Minimalist Design Philosophy: Chimeras design philosophy contains the word clean, which (imo) when changing the color of visited links might disrupt this simplicity and clutter the visual field, contradicting the core design principles of the site.