### PR TITLE
:construction_worker: ignore updated documents on workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,13 @@ on:
     push:
         branches:
             - main
+        paths-ignore:
+            - 'README.md'
+            - 'SECURITY.md'
+            - 'LICENCE'
+            - 'GUIDE.md'
+            - 'CONTRIBUTING.md'
+            - 'CODE_OF_CONDUCT.md'
 
 jobs:
     format-prettier:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,6 +3,13 @@ on:
     pull_request:
         branches:
             - main
+        paths-ignore:
+            - 'README.md'
+            - 'SECURITY.md'
+            - 'LICENCE'
+            - 'GUIDE.md'
+            - 'CONTRIBUTING.md'
+            - 'CODE_OF_CONDUCT.md'
 
 jobs:
     compile-themes:


### PR DESCRIPTION
Updated workflows, `main.yml` and `pull-request.yml`, to not run when the documents below are edited. I thought that it's unnecessary to have the workflows run when only these documents are edited :sweat_smile: 

Documents to ignore:
  - `README.md`
  - `SECURITY.md`
  - `LICENCE`
  - `GUIDE.md`
  - `CONTRIBUTING.md`
  - `CODE_OF_CONDUCT.md`